### PR TITLE
EE-10022 Set USE_SECURE_COOKIE during deployment

### DIFF
--- a/kd/pttg-rps-enquiry/deployment.yaml
+++ b/kd/pttg-rps-enquiry/deployment.yaml
@@ -136,6 +136,8 @@ spec:
               secretKeyRef:
                 name: hof-session-secret
                 key: hof-session-secret
+          - name: USE_SECURE_COOKIE
+            value: {{.USE_SECURE_COOKIE}}
         resources:
           limits:
             cpu: 1000m


### PR DESCRIPTION
This PR is to be merged at the same time as https://github.com/UKHomeOffice/pttg-rps-enquiry-form/pull/141 . It supplies the environment variable USE_SECURE_COOKIE to whatever was supplied by the Drone job