### PR TITLE
EE-14545 removing modsecurity-snippet decalration from prod ingress a…

### DIFF
--- a/kd/pttg-rps-enquiry/ingress-notprod.yaml
+++ b/kd/pttg-rps-enquiry/ingress-notprod.yaml
@@ -10,6 +10,7 @@ metadata:
     ingress.kubernetes.io/whitelist-source-range: "{{.WHITELIST}}"
     stable.k8s.psg.io/kcm.provider: http
     ingress.kubernetes.io/enable-modsecurity: "true"
+    ingress.kubernetes.io/enable-owasp-modsecurity-crs: "true"
   name: pttg-rps-enquiry-ingress-external
 spec:
   tls:

--- a/kd/pttg-rps-enquiry/ingress-notprod.yaml
+++ b/kd/pttg-rps-enquiry/ingress-notprod.yaml
@@ -6,10 +6,10 @@ metadata:
     stable.k8s.psg.io/kcm.class: default
   annotations:
     kubernetes.io/ingress.class: "nginx-external"
-    ingress.kubernetes.io/secure-backends: "true"     # TODO Remove this once ACP have upgraded ingress controller 0.21.0
     ingress.kubernetes.io/backend-protocol: "HTTPS"
     ingress.kubernetes.io/whitelist-source-range: "{{.WHITELIST}}"
     stable.k8s.psg.io/kcm.provider: http
+    ingress.kubernetes.io/enable-modsecurity: "true"
   name: pttg-rps-enquiry-ingress-external
 spec:
   tls:
@@ -24,4 +24,3 @@ spec:
           serviceName: pttg-rps-enquiry
           servicePort: 443
         path: /
-

--- a/kd/pttg-rps-enquiry/ingress-prod.yaml
+++ b/kd/pttg-rps-enquiry/ingress-prod.yaml
@@ -10,6 +10,7 @@ metadata:
     ingress.kubernetes.io/whitelist-source-range: "{{.WHITELIST}}"
     stable.k8s.psg.io/kcm.provider: http
     ingress.kubernetes.io/enable-modsecurity: "true"
+    ingress.kubernetes.io/enable-owasp-modsecurity-crs: "true"
   name: pttg-rps-enquiry-ingress-external-govuk
 spec:
   tls:

--- a/kd/pttg-rps-enquiry/ingress-prod.yaml
+++ b/kd/pttg-rps-enquiry/ingress-prod.yaml
@@ -10,36 +10,6 @@ metadata:
     ingress.kubernetes.io/whitelist-source-range: "{{.WHITELIST}}"
     stable.k8s.psg.io/kcm.provider: http
     ingress.kubernetes.io/enable-modsecurity: "true"
-    ingress.kubernetes.io/modsecurity-snippet: |
-      Include /etc/nginx/modsecurity/modsecurity.conf
-      Include /etc/nginx/owasp-modsecurity-crs/crs-setup.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-901-INITIALIZATION.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-910-IP-REPUTATION.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-912-DOS-PROTECTION.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-913-SCANNER-DETECTION.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-921-PROTOCOL-ATTACK.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-950-DATA-LEAKAGES.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-980-CORRELATION.conf
-      Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
   name: pttg-rps-enquiry-ingress-external-govuk
 spec:
   tls:


### PR DESCRIPTION
…s this is made redundant by ACP upgrade. Also making non-prod ingress match prod ingress so that issues will be identified earlier